### PR TITLE
refactor: don't use deprecated overloads and await promises

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 /*
-   - Welcome! This is a Discord bot used to connect Minecraft chat to 
+   - Welcome! This is a Discord bot used to connect Minecraft chat to
      Discord and vice versa. Open source, with love from xMdb. ❤
 
    - This is mainly for the Hypixel Knights Discord server,
@@ -9,9 +9,9 @@
    - Read more about this bot in the README.md!
 
    ! WARNING
-   | This application will login to Hypixel using Mineflayer which is not a 
-   | normal Minecraft client, this could result in your Minecraft account 
-   | getting banned from Hypixel, so use this application at your own risk. 
+   | This application will login to Hypixel using Mineflayer which is not a
+   | normal Minecraft client, this could result in your Minecraft account
+   | getting banned from Hypixel, so use this application at your own risk.
    | I am not liable for any damages and no warranty is provided as outlined
    | in GPL-3.0 License.                                                      */
 
@@ -121,18 +121,18 @@ function spawnBot() {
          }
          const newCleanMessage = message.content.replace(/\r?\n|\r/g, ' ');
          minebot.chat(`/gc ${message.author.username} > ${newCleanMessage}`);
-         toDiscordChat(
+         await toDiscordChat(
             `${config.emotes.fromDiscord} **${message.author.username}: ${Util.escapeMarkdown(message.content)}**`
          );
          await message.delete();
       } catch (err) {
          console.error(err);
-         message.channel.send({
+         await message.channel.send({
             content: `**:warning: ${message.author}, there was an error while performing that task.**`,
          });
       }
       if (message.content.startsWith(`/`)) {
-         toDiscordChat(`https://media.tenor.com/images/e6cd56fc29e429ff89fef2fd2bdfaae2/tenor.gif`);
+         await toDiscordChat(`https://media.tenor.com/images/e6cd56fc29e429ff89fef2fd2bdfaae2/tenor.gif`);
       }
    });
 }
@@ -176,7 +176,7 @@ bot.on('interactionCreate', async (interaction) => {
          content: config.messages.errorDev,
          ephemeral: true,
       });
-      webhook.send(`**General command error:** \`\`\`${err}\`\`\``);
+      await webhook.send(`**General command error:** \`\`\`${err}\`\`\``);
    }
 });
 

--- a/commands/Developer Only/eval.js
+++ b/commands/Developer Only/eval.js
@@ -53,7 +53,7 @@ module.exports = {
             .setFooter({ text:`Execution time: ${end - start}ms`, iconURL: interaction.user.displayAvatarURL({ dynamic: true }) });
 
          if (evaled.length > 999) {
-            interaction.editReply({
+            await interaction.editReply({
                embeds: [longRequestEmbed],
             });
             hastebin
@@ -62,7 +62,7 @@ module.exports = {
                   contentType: 'text/plain',
                   server: 'https://haste.zneix.eu/',
                })
-               .then((url) => {
+               .then(async (url) => {
                   const resultEmbed = new MessageEmbed()
                      .setTitle('Evaluate - Result Too Long  📜')
                      .setColor(config.colours.informational)
@@ -75,8 +75,8 @@ module.exports = {
                         value: `[Click to view result!](${url})`,
                      })
                      .setTimestamp()
-                  return interaction.editReply({
                      .setFooter({ text: `Execution time: ${end - start}ms`, iconURL: interaction.user.displayAvatarURL({ dynamic: true }) });
+                  return await interaction.editReply({
                      embeds: [resultEmbed],
                   });
                })
@@ -97,8 +97,8 @@ module.exports = {
                value: `\`\`\`yaml\n${evaled}\`\`\``,
             })
             .setTimestamp()
-         return interaction.editReply({
             .setFooter({ text: `Execution time: ${end - start}ms`, iconURL: interaction.user.displayAvatarURL({ dynamic: true }) });
+         return await interaction.editReply({
             embeds: [evalEmbed],
          });
 
@@ -116,11 +116,11 @@ module.exports = {
                value: `\`\`\`fix\n${error}\`\`\``,
             })
             .setTimestamp()
-         return interaction.editReply({
             .setFooter({
                text: `Executed by ${interaction.user.username}#${interaction.user.discriminator}`,
                iconURL: interaction.user.displayAvatarURL({ dynamic: true })
             });
+         return await interaction.editReply({
             content: `An error has occurred.`,
             embeds: [errorEmbed],
          });

--- a/commands/Developer Only/eval.js
+++ b/commands/Developer Only/eval.js
@@ -50,7 +50,7 @@ module.exports = {
             .setColor(config.colours.informational)
             .setDescription(`Generating Hastebin link. Please wait... :hourglass:`)
             .setTimestamp()
-            .setFooter(`Execution time: ${end - start}ms`, interaction.user.displayAvatarURL({ dynamic: true }));
+            .setFooter({ text:`Execution time: ${end - start}ms`, iconURL: interaction.user.displayAvatarURL({ dynamic: true }) });
 
          if (evaled.length > 999) {
             interaction.editReply({
@@ -75,8 +75,8 @@ module.exports = {
                         value: `[Click to view result!](${url})`,
                      })
                      .setTimestamp()
-                     .setFooter(`Execution time: ${end - start}ms`, interaction.user.displayAvatarURL({ dynamic: true }));
                   return interaction.editReply({
+                     .setFooter({ text: `Execution time: ${end - start}ms`, iconURL: interaction.user.displayAvatarURL({ dynamic: true }) });
                      embeds: [resultEmbed],
                   });
                })
@@ -97,8 +97,8 @@ module.exports = {
                value: `\`\`\`yaml\n${evaled}\`\`\``,
             })
             .setTimestamp()
-            .setFooter(`Execution time: ${end - start}ms`, interaction.user.displayAvatarURL({ dynamic: true }));
          return interaction.editReply({
+            .setFooter({ text: `Execution time: ${end - start}ms`, iconURL: interaction.user.displayAvatarURL({ dynamic: true }) });
             embeds: [evalEmbed],
          });
 
@@ -116,11 +116,11 @@ module.exports = {
                value: `\`\`\`fix\n${error}\`\`\``,
             })
             .setTimestamp()
-            .setFooter(
-               `Executed by ${interaction.user.username}#${interaction.user.discriminator}`,
-               interaction.user.displayAvatarURL({ dynamic: true })
-            );
          return interaction.editReply({
+            .setFooter({
+               text: `Executed by ${interaction.user.username}#${interaction.user.discriminator}`,
+               iconURL: interaction.user.displayAvatarURL({ dynamic: true })
+            });
             content: `An error has occurred.`,
             embeds: [errorEmbed],
          });

--- a/commands/Developer Only/register.js
+++ b/commands/Developer Only/register.js
@@ -66,7 +66,7 @@ module.exports = {
          .setColor(config.colours.error)
          .setDescription(`You are going to register a new **${commandType}** command called **${commandToReg}**.`)
          .setTimestamp()
-         .setFooter('Note: Global commands will be cached for up to one hour!');
+         .setFooter({ text: 'Note: Global commands will be cached for up to one hour!' });
       await interaction.reply({
          embeds: [confirmDenyEmbed],
          components: [confirmDenyButtons],
@@ -78,18 +78,18 @@ module.exports = {
          .setColor(config.colours.success)
          .setDescription(`Successfully registered new ${commandType} command **${commandToReg}**.`)
          .setTimestamp()
-         .setFooter(
-            `Executed by ${interaction.user.username}#${interaction.user.discriminator}`,
-            interaction.user.displayAvatarURL({ dynamic: true })
-         );
+         .setFooter({
+            text: `Executed by ${interaction.user.username}#${interaction.user.discriminator}`,
+            iconURL: interaction.user.displayAvatarURL({ dynamic: true })
+         });
       const cancelled = new MessageEmbed()
          .setColor(config.colours.error)
          .setDescription(`**Cancelled!** No commands were registered!`)
          .setTimestamp()
-         .setFooter(
-            `Executed by ${interaction.user.username}#${interaction.user.discriminator}`,
-            interaction.user.displayAvatarURL({ dynamic: true })
-         );
+         .setFooter({
+            text: `Executed by ${interaction.user.username}#${interaction.user.discriminator}`,
+            iconURL: interaction.user.displayAvatarURL({ dynamic: true })
+         });
 
       collector.on('collect', async (buttonPressed) => {
          if (buttonPressed.customId === 'confirm') {

--- a/commands/Developer Only/restart.js
+++ b/commands/Developer Only/restart.js
@@ -29,7 +29,7 @@ module.exports = {
          .setColor(config.colours.informational)
          .setDescription('Process ended. Restarting...')
          .setTimestamp()
-         .setFooter(config.messages.footer);
+         .setFooter({ text: config.messages.footer });
       await interaction.deferReply();
       await wait(1000);
       interaction

--- a/commands/Developer Only/restart.js
+++ b/commands/Developer Only/restart.js
@@ -32,7 +32,7 @@ module.exports = {
          .setFooter({ text: config.messages.footer });
       await interaction.deferReply();
       await wait(1000);
-      interaction
+      await interaction
          .editReply({
             embeds: [success],
          })

--- a/commands/Developer Only/restart.js
+++ b/commands/Developer Only/restart.js
@@ -1,6 +1,6 @@
+const { setTimeout: wait } = require("node:timers/promises");
 const { MessageEmbed } = require('discord.js');
 const config = require('../../config');
-const wait = require('util').promisify(setTimeout);
 
 module.exports = {
    name: 'restart',

--- a/commands/Developer Only/shutdown.js
+++ b/commands/Developer Only/shutdown.js
@@ -30,7 +30,7 @@ module.exports = {
          .setColor(config.colours.informational)
          .setDescription('Process ended. Please restart the bot manually.')
          .setTimestamp()
-         .setFooter(config.messages.footer);
+         .setFooter({ text: config.messages.footer });
       await interaction.deferReply();
       await wait(1000);
       interaction

--- a/commands/Developer Only/shutdown.js
+++ b/commands/Developer Only/shutdown.js
@@ -1,7 +1,7 @@
+const { setTimeout: wait } = require("node:timers/promises");
 const { MessageEmbed } = require('discord.js');
 const nc = require('node-cmd');
 const config = require('../../config');
-const wait = require('util').promisify(setTimeout);
 
 module.exports = {
    name: 'shutdown',

--- a/commands/Developer Only/shutdown.js
+++ b/commands/Developer Only/shutdown.js
@@ -33,7 +33,7 @@ module.exports = {
          .setFooter({ text: config.messages.footer });
       await interaction.deferReply();
       await wait(1000);
-      interaction
+      await interaction
          .editReply({
             embeds: [success],
          })

--- a/commands/Informational/ping.js
+++ b/commands/Informational/ping.js
@@ -22,10 +22,10 @@ module.exports = {
                }ms`
             )
             .setTimestamp()
-            .setFooter(config.messages.footer);
          interaction.reply({
             embeds: [pingCmd],
          });
+         .setFooter({ text: config.messages.footer });
       });
    },
 };

--- a/commands/Informational/ping.js
+++ b/commands/Informational/ping.js
@@ -11,21 +11,20 @@ module.exports = {
       };
       await bot.application?.commands.create(data);
 
-      interaction.channel.send(':ping_pong:').then(async (msg) => {
-         msg.delete();
-         const pingCmd = new MessageEmbed()
-            .setTitle('Pong!')
-            .setColor(config.colours.success)
-            .setDescription(
-               `:heartbeat: **Websocket Heartbeat**: ${bot.ws.ping}ms\n:bullettrain_front: **Roundtrip Latency**: ${
-                  msg.createdTimestamp - interaction.createdTimestamp
-               }ms`
-            )
-            .setTimestamp()
-         interaction.reply({
-            embeds: [pingCmd],
-         });
+      const msg = await interaction.channel.send(':ping_pong:');
+      await msg.delete();
+      const pingCmd = new MessageEmbed()
+         .setTitle('Pong!')
+         .setColor(config.colours.success)
+         .setDescription(
+            `:heartbeat: **Websocket Heartbeat**: ${bot.ws.ping}ms\n:bullettrain_front: **Roundtrip Latency**: ${
+               msg.createdTimestamp - interaction.createdTimestamp
+            }ms`
+         )
+         .setTimestamp()
          .setFooter({ text: config.messages.footer });
+      await interaction.reply({
+         embeds: [pingCmd],
       });
    },
 };

--- a/commands/Informational/uptime.js
+++ b/commands/Informational/uptime.js
@@ -23,8 +23,8 @@ module.exports = {
             `Time since last restart:\n\n**${days}** day(s)\n**${hours}** hour(s)\n**${minutes}** minute(s)\n**${seconds}** second(s)`
          )
          .setTimestamp()
-         .setFooter(config.messages.footer);
       interaction.reply({
+         .setFooter({ text: config.messages.footer });
          embeds: [uptimeEmbed],
       });
    },

--- a/commands/Informational/uptime.js
+++ b/commands/Informational/uptime.js
@@ -23,8 +23,8 @@ module.exports = {
             `Time since last restart:\n\n**${days}** day(s)\n**${hours}** hour(s)\n**${minutes}** minute(s)\n**${seconds}** second(s)`
          )
          .setTimestamp()
-      interaction.reply({
          .setFooter({ text: config.messages.footer });
+      await interaction.reply({
          embeds: [uptimeEmbed],
       });
    },

--- a/commands/Utility/say.js
+++ b/commands/Utility/say.js
@@ -56,16 +56,16 @@ module.exports = {
          });
          const log = new MessageEmbed()
             .setColor(config.colours.informational)
-            .setAuthor(
-               `${interaction.user.username}#${interaction.user.discriminator}`,
-               interaction.user.displayAvatarURL({ dynamic: true })
-            )
+            .setAuthor({
+               name: `${interaction.user.username}#${interaction.user.discriminator}`,
+               iconURL: interaction.user.displayAvatarURL({ dynamic: true })
+            })
             .setDescription(`**Say command in **<#${destination.id}> [Jump to Message](${sayMessage.url})`)
-            .addField(`Message`, message)
+            .addFields({ name: `Message`, value: message })
             .setTimestamp()
-            .setFooter(`User ID: ${interaction.user.id}`);
          guildWebhook.send({ embeds: [log] });
          interaction.reply({ content: `Done! [Click to view message](${sayMessage.url})`, ephemeral: true });
+            .setFooter({ text: `User ID: ${interaction.user.id}` });
       } catch (error) {
          interaction.reply({
             content: `I cannot access that channel.`,

--- a/commands/Utility/say.js
+++ b/commands/Utility/say.js
@@ -46,7 +46,7 @@ module.exports = {
       if (!destination) destination = interaction.channel;
       try {
          if (destination.type === 'GUILD_VOICE' || destination.type === 'GUILD_STAGE_VOICE') {
-            return interaction.reply({ content: `The channel provided is not a text channel.`, ephemeral: true });
+            return await interaction.reply({ content: `The channel provided is not a text channel.`, ephemeral: true });
          }
          const sayMessage = await bot.channels.cache.get(destination.id).send({
             content: message,
@@ -63,11 +63,11 @@ module.exports = {
             .setDescription(`**Say command in **<#${destination.id}> [Jump to Message](${sayMessage.url})`)
             .addFields({ name: `Message`, value: message })
             .setTimestamp()
-         guildWebhook.send({ embeds: [log] });
-         interaction.reply({ content: `Done! [Click to view message](${sayMessage.url})`, ephemeral: true });
             .setFooter({ text: `User ID: ${interaction.user.id}` });
+         await guildWebhook.send({ embeds: [log] });
+         await interaction.reply({ content: `Done! [Click to view message](${sayMessage.url})`, ephemeral: true });
       } catch (error) {
-         interaction.reply({
+         await interaction.reply({
             content: `I cannot access that channel.`,
             ephemeral: true,
          });

--- a/commands/Utility/send.js
+++ b/commands/Utility/send.js
@@ -42,7 +42,7 @@ module.exports = {
             .setDescription(`Command sent!`)
             .setImage(image)
             .setTimestamp()
-            .setFooter(config.messages.footer);
+            .setFooter({ text: config.messages.footer });
          minebot.chat(`/${msg}`);
          interaction.reply({
             embeds: [success],

--- a/commands/Utility/send.js
+++ b/commands/Utility/send.js
@@ -44,7 +44,7 @@ module.exports = {
             .setTimestamp()
             .setFooter({ text: config.messages.footer });
          minebot.chat(`/${msg}`);
-         interaction.reply({
+         await interaction.reply({
             embeds: [success],
          });
       } catch (err) {

--- a/events/discord/ready.js
+++ b/events/discord/ready.js
@@ -15,7 +15,7 @@ module.exports = {
             type: 'LISTENING',
          });
       }, 60 * 1000);
-      bot.guilds.cache.get(config.ids.server).channels.cache.get(config.ids.guildChannel).send({
+      await bot.guilds.cache.get(config.ids.server).channels.cache.get(config.ids.guildChannel).send({
          content: `<:yes:829640052531134464> Bot has reconnected to Discord.`,
       });
    },

--- a/events/minecraft/chat/getOnline.js
+++ b/events/minecraft/chat/getOnline.js
@@ -5,7 +5,7 @@ module.exports = {
    name: 'getOnline',
    async execute(numOfOnline) {
       // —— Bot reconnection log
-      toDiscordChat(
+      await toDiscordChat(
          `${config.emotes.getOnline} Bot has reconnected to Hypixel. There are **${numOfOnline - 1}** other members online.`
       );
    },

--- a/events/minecraft/chat/guildChat.js
+++ b/events/minecraft/chat/guildChat.js
@@ -6,6 +6,6 @@ module.exports = {
    name: 'guildChat',
    async execute(rank, playername, grank, message) {
       if (playername === minebot.username) return;
-      toDiscordChat(`${config.emotes.guildChat} **${rank ?? ''}${playername}: ${Util.escapeMarkdown(message)}**`);
+      await toDiscordChat(`${config.emotes.guildChat} **${rank ?? ''}${playername}: ${Util.escapeMarkdown(message)}**`);
    },
 };

--- a/events/minecraft/chat/guildLevelUp.js
+++ b/events/minecraft/chat/guildLevelUp.js
@@ -4,6 +4,6 @@ const config = require('../../../config');
 module.exports = {
    name: 'guildLevelUp',
    async execute(level) {
-      toDiscordChat(`${config.emotes.guildLevelUp} **Yay!** The guild has leveled up to **Level ${level}**!`);
+      await toDiscordChat(`${config.emotes.guildLevelUp} **Yay!** The guild has leveled up to **Level ${level}**!`);
    },
 };

--- a/events/minecraft/chat/joinLeave.js
+++ b/events/minecraft/chat/joinLeave.js
@@ -5,6 +5,6 @@ module.exports = {
    name: 'joinLeave',
    async execute(playername, joinLeave) {
       if (playername === minebot.username) return;
-      toDiscordChat(`${config.emotes.joinLeave} **${playername} ${joinLeave}.**`);
+      await toDiscordChat(`${config.emotes.joinLeave} **${playername} ${joinLeave}.**`);
    },
 };

--- a/events/minecraft/chat/memberKicked.js
+++ b/events/minecraft/chat/memberKicked.js
@@ -16,7 +16,7 @@ module.exports = {
       const avatar = getAvatar(playername1);
       const discordTag = await getPlayerDiscord(playername1);
 
-      toDiscordChat(
+      await toDiscordChat(
          `${config.emotes.memberKicked} ${rank1 ?? ''}${playername1} was kicked by ${rank2 ?? ''}${playername2}! RIP!`
       );
       if (playername1 === 'Guild') return console.log('memberKicked debug: Success.');
@@ -30,6 +30,6 @@ module.exports = {
             `**Left At**: <t:${unix}:F> (<t:${unix}:R>)\n**Discord**: ${discordObject} (${discordTag})\n**Kicked By**: ${playername2}`
          )
          .setTimestamp();
-      guildWebhook.send({ embeds: [memberKicked] });
+      await guildWebhook.send({ embeds: [memberKicked] });
    },
 };

--- a/events/minecraft/chat/memberKicked.js
+++ b/events/minecraft/chat/memberKicked.js
@@ -24,8 +24,8 @@ module.exports = {
       const discordObject = bot.users.cache.find((user) => user.tag === discordTag) ?? 'Not Found';
       const memberKicked = new MessageEmbed()
          .setColor('#F18002')
-         .setAuthor(playername1, avatar)
-         .setFooter(`A member was kicked from the guild!`)
+         .setAuthor({ name: playername1, iconURL: avatar })
+         .setFooter({ text: `A member was kicked from the guild!` })
          .setDescription(
             `**Left At**: <t:${unix}:F> (<t:${unix}:R>)\n**Discord**: ${discordObject} (${discordTag})\n**Kicked By**: ${playername2}`
          )

--- a/events/minecraft/chat/memberLeave.js
+++ b/events/minecraft/chat/memberLeave.js
@@ -22,8 +22,8 @@ module.exports = {
       const discordObject = bot.users.cache.find((user) => user.tag === discordTag) ?? 'Not Found';
       const memberLeave = new MessageEmbed()
          .setColor(config.colours.error)
-         .setAuthor(playername, avatar)
-         .setFooter(`A member has left the guild.`)
+         .setAuthor({ name: playername, iconURL: avatar })
+         .setFooter({ text: `A member has left the guild.` })
          .setDescription(`**Left At**: <t:${unix}:F> (<t:${unix}:R>)\n**Discord**: ${discordObject} / ${discordTag}`)
          .setTimestamp();
       guildWebhook.send({ embeds: [memberLeave] });

--- a/events/minecraft/chat/memberLeave.js
+++ b/events/minecraft/chat/memberLeave.js
@@ -16,7 +16,7 @@ module.exports = {
       const avatar = getAvatar(playername);
       const discordTag = await getPlayerDiscord(playername);
 
-      toDiscordChat(`${config.emotes.memberLeave} ${rank ?? ''}${playername} left the guild.`);
+      await toDiscordChat(`${config.emotes.memberLeave} ${rank ?? ''}${playername} left the guild.`);
       if (playername === 'Guild') return console.log('memberLeave debug: Success.');
 
       const discordObject = bot.users.cache.find((user) => user.tag === discordTag) ?? 'Not Found';
@@ -26,6 +26,6 @@ module.exports = {
          .setFooter({ text: `A member has left the guild.` })
          .setDescription(`**Left At**: <t:${unix}:F> (<t:${unix}:R>)\n**Discord**: ${discordObject} / ${discordTag}`)
          .setTimestamp();
-      guildWebhook.send({ embeds: [memberLeave] });
+      await guildWebhook.send({ embeds: [memberLeave] });
    },
 };

--- a/events/minecraft/chat/newMember.js
+++ b/events/minecraft/chat/newMember.js
@@ -22,8 +22,8 @@ module.exports = {
       const discordObject = bot.users.cache.find((user) => user.tag === discordTag) ?? 'Not Found';
       const newMember = new MessageEmbed()
          .setColor(config.colours.success)
-         .setAuthor(playername, avatar)
-         .setFooter(`A new member joined the guild!`)
+         .setAuthor({ name: playername, iconURL: avatar })
+         .setFooter({ text:`A new member joined the guild!` })
          .setDescription(`**Joined**: <t:${unix}:F> (<t:${unix}:R>)\n**Discord**: ${discordObject} / ${discordTag}`)
          .setTimestamp();
       guildWebhook.send({ embeds: [newMember] });

--- a/events/minecraft/chat/newMember.js
+++ b/events/minecraft/chat/newMember.js
@@ -15,8 +15,8 @@ module.exports = {
       const unix = getCurrentUnix();
       const avatar = getAvatar(playername);
       const discordTag = await getPlayerDiscord(playername);
-      
-      toDiscordChat(`${config.emotes.newMember} ${rank ?? ''}${playername} joined the guild!`);
+
+      await toDiscordChat(`${config.emotes.newMember} ${rank ?? ''}${playername} joined the guild!`);
       if (playername === 'Guild') return console.log('newMember debug: Success.');
 
       const discordObject = bot.users.cache.find((user) => user.tag === discordTag) ?? 'Not Found';
@@ -26,6 +26,6 @@ module.exports = {
          .setFooter({ text:`A new member joined the guild!` })
          .setDescription(`**Joined**: <t:${unix}:F> (<t:${unix}:R>)\n**Discord**: ${discordObject} / ${discordTag}`)
          .setTimestamp();
-      guildWebhook.send({ embeds: [newMember] });
+      await guildWebhook.send({ embeds: [newMember] });
    },
 };

--- a/events/minecraft/chat/promotedDemoted.js
+++ b/events/minecraft/chat/promotedDemoted.js
@@ -5,7 +5,7 @@ module.exports = {
    name: 'promotedDemoted',
    async execute(rank, playername, grankChangeType, grank1, grank2) {
       if (playername === 'Guild') return console.log('promotedDemoted debug: Success.');
-      toDiscordChat(
+      await toDiscordChat(
          `${config.emotes.promotedDemoted} ${
             rank ?? ''
          }${playername} has been ${grankChangeType} from ${grank1} to ${grank2}.`

--- a/events/minecraft/chat/questComplete.js
+++ b/events/minecraft/chat/questComplete.js
@@ -4,6 +4,6 @@ const config = require('../../../config');
 module.exports = {
    name: 'questComplete',
    async execute() {
-      toDiscordChat(`${config.emotes.questComplete} **Yay!** The guild has completed **this week's Guild Quest**!`);
+      await toDiscordChat(`${config.emotes.questComplete} **Yay!** The guild has completed **this week's Guild Quest**!`);
    },
 };

--- a/events/minecraft/chat/questTierComplete.js
+++ b/events/minecraft/chat/questTierComplete.js
@@ -4,7 +4,7 @@ const config = require('../../../config');
 module.exports = {
    name: 'questTierComplete',
    async execute(tier) {
-      toDiscordChat(
+      await toDiscordChat(
          `${config.emotes.questTierComplete} **Yay!** The guild has completed **Tier ${tier}** of **this week's Guild Quest**!`
       );
    },

--- a/events/minecraft/handler/error.js
+++ b/events/minecraft/handler/error.js
@@ -12,9 +12,9 @@ module.exports = {
    async execute(error) {
       console.log(chalk.redBright('Error event fired.'));
       console.error(error);
-      webhook.send(`**Minebot: Error** \`\`\`${error}\`\`\``);
+      await webhook.send(`**Minebot: Error** \`\`\`${error}\`\`\``);
       console.log(chalk.redBright('Restarting in 10 seconds.'));
-      toDiscordChat(`${config.emotes.error} The bot has encountered an unknown error and will restart shortly.`);
+      await toDiscordChat(`${config.emotes.error} The bot has encountered an unknown error and will restart shortly.`);
       setTimeout(() => {
          process.exit(1);
       }, 10 * 1000);

--- a/events/minecraft/handler/kicked.js
+++ b/events/minecraft/handler/kicked.js
@@ -12,9 +12,9 @@ module.exports = {
    async execute(reason) {
       console.log(chalk.redBright('The bot was kicked.'));
       console.error(reason);
-      webhook.send(`**The bot was kicked. Reason:** \`\`\`${reason}\`\`\``);
+      await webhook.send(`**The bot was kicked. Reason:** \`\`\`${reason}\`\`\``);
       console.log(chalk.redBright('Restarting in 10 seconds.'));
-      toDiscordChat(
+      await toDiscordChat(
          `${config.emotes.kicked} The bot was kicked from the server and will reconnect shortly. Reason: \`\`\`${reason}\`\`\``
       );
       setTimeout(() => {

--- a/test/minebot.test.js
+++ b/test/minebot.test.js
@@ -4,9 +4,9 @@ const squid = require('flying-squid');
 const mineflayer = require('mineflayer');
 const regex = require('../func/regex');
 function once(emitter, event, options = {}) {
-   return new Promise(function (resolve, reject) {
+   return new Promise(function(resolve, reject) {
       if (options.array) {
-         emitter.once(event, function (...args) {
+         emitter.once(event, function(...args) {
             resolve(args);
          });
       } else {


### PR DESCRIPTION
This PR is a small refactor that changes all MessageEmbed#setAuthor, #addField and #setFooter to use objects instead of strings (and addFields instead of addField since discord.js has been talking about deprecating that too), adds `await` to all promises to make sure the code runs in the order it's supposed to run and optimises the `wait` function by turning it into an import from node:timers/promises. The bot needs a bigger refactor in the way commands are registered but that's something for a different PR, if you do want me to open that